### PR TITLE
Update Taxon client

### DIFF
--- a/dist/amd/kb_sdk_clients/TaxonAPI/dev/TaxonAPIClient.js
+++ b/dist/amd/kb_sdk_clients/TaxonAPI/dev/TaxonAPIClient.js
@@ -189,7 +189,7 @@ define([
         this.get_all_data = function (p) {
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'TaxonAPI.get_version',
+                    var method = 'TaxonAPI.get_all_data',
                         params = [p];
                     return jsonRpc.request(serviceStatus.url, method, params, 1, options());
                 });
@@ -198,7 +198,7 @@ define([
         this.get_decorated_scientific_lineage = function (p) {
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'TaxonAPI.get_version',
+                    var method = 'TaxonAPI.get_decorated_scientific_lineage',
                         params = [p];
                     return jsonRpc.request(serviceStatus.url, method, params, 1, options());
                 });

--- a/dist/amd/kb_sdk_clients/TaxonAPI/dev/TaxonAPIClient.js
+++ b/dist/amd/kb_sdk_clients/TaxonAPI/dev/TaxonAPIClient.js
@@ -185,6 +185,24 @@ define([
                     return jsonRpc.request(serviceStatus.url, method, params, 1, options());
                 });
         };
+        
+        this.get_all_data = function (p) {
+            return this.lookupModule()
+                .then(function (serviceStatus) {
+                    var method = 'TaxonAPI.get_version',
+                        params = [p];
+                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                });
+        };
+
+        this.get_decorated_scientific_lineage = function (p) {
+            return this.lookupModule()
+                .then(function (serviceStatus) {
+                    var method = 'TaxonAPI.get_version',
+                        params = [p];
+                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                });
+        };
 
         this.get_version = function (ref) {
             return this.lookupModule()


### PR DESCRIPTION
Added two additional functions to the API to support changes in https://github.com/kbase/taxon_api/tree/batch-data, these changes were tested locally.

Note that in the updated spec, the parameter object is named 'params'.  This will conflict with the functions internal usage of a 'params' variable.  In fact, using 'method' or 'options' or some other things might also cause things to break.  Not sure if we handled these cases before, but I know there are a lot of functions that use the name 'params'.
