### PR TITLE
Improvements to method invocation and exceptions

### DIFF
--- a/dist/amd/kb_sdk_clients/AssemblyAPI/dev/AssemblyAPIClient.js
+++ b/dist/amd/kb_sdk_clients/AssemblyAPI/dev/AssemblyAPIClient.js
@@ -6,6 +6,7 @@ define([
     'use strict';
 
     function AssemblyAPI(arg) {
+        var module = 'AssemblyAPI';
         // Establish an auth object which has properties token and user_id.
         var auth;
         if (typeof arg.auth === 'function') {
@@ -31,121 +32,179 @@ define([
         }
 
         this.lookupModule = function () {
-            var method = 'ServiceWizard.get_service_status',
+            var func = 'get_service_status',
                 params = [{
-                        module_name: 'AssemblyAPI',
-                        version: arg.version || 'dev'
+                        module_name: module,
+                        version: arg.version
                     }];
-            return jsonRpc.request(arg.url, method, params, 1, options());
+            return jsonRpc.request(arg.url, 'ServiceWizard', func, params, 1, options());
         };
 
+        /*
+         * ref
+         */
+        this.get_assembly_id = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_assembly_id';
 
-        this.get_assembly_id = function (ref) {
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'AssemblyAPI.get_assembly_id',
-                        params = [ref];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_genome_annotations = function (ref) {
+
+        /*
+         * ref
+         */
+        this.get_genome_annotations = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_genome_annotations';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'AssemblyAPI.get_genome_annotations',
-                        params = [ref];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_external_source_info = function (ref) {
+
+        /*
+         * ref
+         */
+        this.get_external_source_info = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_external_source_info';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'AssemblyAPI.get_external_source_info',
-                        params = [ref];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_stats = function (ref) {
+
+        /*
+         * ref
+         */
+        this.get_stats = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_stats';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'AssemblyAPI.get_stats',
-                        params = [ref];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_number_contigs = function (ref) {
+
+        /*
+         * ref
+         */
+        this.get_number_contigs = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_number_contigs';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'AssemblyAPI.get_number_contigs',
-                        params = [ref];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_gc_content = function (ref) {
+
+        /*
+         * ref
+         */
+        this.get_gc_content = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_gc_content';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'AssemblyAPI.get_gc_content',
-                        params = [ref];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_dna_size = function (ref) {
+
+        /*
+         * ref
+         */
+        this.get_dna_size = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_dna_size';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'AssemblyAPI.get_dna_size',
-                        params = [ref];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_contig_ids = function (ref) {
+
+        /*
+         * ref
+         */
+        this.get_contig_ids = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_contig_ids';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'AssemblyAPI.get_contig_ids',
-                        params = [ref];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_contig_lengths = function (ref, contig_id_list) {
+
+        /*
+         * ref, contig_id_list
+         */
+        this.get_contig_lengths = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_contig_lengths';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'AssemblyAPI.get_contig_lengths',
-                        params = [ref, contig_id_list];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });            
         };
 
-        this.get_contig_gc_content = function (ref, contig_id_list) {
+
+        /*
+         * ref, contig_id_list
+         */
+        this.get_contig_gc_content = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_contig_gc_content';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'AssemblyAPI.get_contig_gc_content',
-                        params = [ref, contig_id_list];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 }); 
         };
 
-        this.get_contigs = function (ref, contig_id_list) {
+
+        /*
+         * ref, contig_id_list
+         */
+        this.get_contigs = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_contigs';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'AssemblyAPI.get_contigs',
-                        params = [ref, contig_id_list];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 }); 
 
         };
 
+
+        /*
+         * 
+         */
         this.status = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_contigs';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'AssemblyAPI.get_contigs',
-                        params = [];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
     }

--- a/dist/amd/kb_sdk_clients/GenomeAnnotationAPI/dev/GenomeAnnotationAPIClient.js
+++ b/dist/amd/kb_sdk_clients/GenomeAnnotationAPI/dev/GenomeAnnotationAPIClient.js
@@ -1,11 +1,12 @@
 /*global define */
-/*jslint white:true,browser:true,jsnomen:true*/
+/*jslint white:true,browser:true,nomen:true*/
 define([
     '../../jsonRpc-native'
 ], function (jsonRpc) {
     'use strict';
 
     function GenomeAnnotationAPI(arg) {
+        var module = 'GenomeAnnotationAPI';
         // Establish an auth object which has properties token and user_id.
         var auth;
         if (typeof arg.auth === 'function') {
@@ -13,7 +14,7 @@ define([
         } else {
             auth = arg.auth || {};
         }
-        
+
         if (!arg.url) {
             throw new Error('The service discovery url was not provided');
         }
@@ -30,245 +31,349 @@ define([
         }
 
         this.lookupModule = function () {
-            var method = 'ServiceWizard.get_service_status',
+            var func = 'get_service_status',
                 params = [{
-                        module_name: 'GenomeAnnotationAPI',
+                        module_name: module,
                         version: arg.version
                     }];
-            return jsonRpc.request(arg.url, method, params, 1, options());
+            return jsonRpc.request(arg.url, 'ServiceWizard', func, params, 1, options());
         };
 
-        this.get_taxon = function (inputs_get_taxon) {
+        /*
+         * inputs_get_taxon
+         */
+        this.get_taxon = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_taxon';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'GenomeAnnotationAPI.get_taxon',
-                        params = [inputs_get_taxon];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_assembly = function (inputs_get_assembly) {
+        /*
+         * inputs_get_assembly
+         */
+        this.get_assembly = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_assembly';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'GenomeAnnotationAPI.get_assembly',
-                        params = [inputs_get_assembly];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_feature_types = function (inputs_get_feature_types) {
+        /*
+         * inputs_get_feature_types
+         */
+        this.get_feature_types = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_feature_types';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'GenomeAnnotationAPI.get_feature_types',
-                        params = [inputs_get_feature_types];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_feature_type_descriptions = function (inputs_get_feature_type_descriptions) {
+        /*
+         * inputs_get_feature_type_descriptions
+         */
+        this.get_feature_type_descriptions = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_feature_type_descriptions';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'GenomeAnnotationAPI.get_feature_type_descriptions',
-                        params = [inputs_get_feature_type_descriptions];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_feature_type_counts = function (inputs_get_feature_type_counts) {
+        /*
+         * inputs_get_feature_type_counts
+         */
+        this.get_feature_type_counts = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_feature_type_counts';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'GenomeAnnotationAPI.get_feature_type_counts',
-                        params = [inputs_get_feature_type_counts];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_feature_ids = function (inputs_get_feature_ids) {
+        /*
+         * inputs_get_feature_ids
+         */
+        this.get_feature_ids = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_feature_ids';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'GenomeAnnotationAPI.get_feature_ids',
-                        params = [inputs_get_feature_ids];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_features = function (inputs_get_features) {
-            return this.lookupModule()
-                .then(function (serviceStatus) {
-                    var method = 'GenomeAnnotationAPI.get_features',
-                        params = [inputs_get_features];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
-                });            
-        };
+        /*
+         * inputs_get_features
+         */
+        this.get_features = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_features';
 
-        this.get_features2 = function (params) {
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'GenomeAnnotationAPI.get_features2',
-                        params = [params];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_proteins = function (inputs_get_proteins) {
+        /*
+         * params
+         */
+        this.get_features2 = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_features2';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'GenomeAnnotationAPI.get_proteins',
-                        params = [inputs_get_proteins];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_feature_locations = function (inputs_get_feature_locations) {
+        /*
+         * inputs_get_proteins
+         */
+        this.get_proteins = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_proteins';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'GenomeAnnotationAPI.get_feature_locations',
-                        params = [inputs_get_feature_locations];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_feature_publications = function (inputs_get_feature_publications) {
+        /*
+         * inputs_get_feature_locations
+         */
+        this.get_feature_locations = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_feature_locations';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'GenomeAnnotationAPI.get_feature_publications',
-                        params = [inputs_get_feature_publications];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_feature_dna = function (inputs_get_feature_dna) {
+        /*
+         * inputs_get_feature_publications
+         */
+        this.get_feature_publications = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_feature_publications';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'GenomeAnnotationAPI.get_feature_dna',
-                        params = [inputs_get_feature_dna];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_feature_functions = function (inputs_get_feature_functions) {
+        /*
+         * inputs_get_feature_dna
+         */
+        this.get_feature_dna = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_feature_dna';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'GenomeAnnotationAPI.get_feature_functions',
-                        params = [inputs_get_feature_functions];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_feature_aliases = function (inputs_get_feature_aliases) {
+        /*
+         * inputs_get_feature_functions
+         */
+        this.get_feature_functions = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_feature_functions';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'GenomeAnnotationAPI.get_feature_aliases',
-                        params = [inputs_get_feature_aliases];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_cds_by_gene = function (inputs_get_cds_by_gene) {
+        /*
+         * inputs_get_feature_aliases
+         */
+        this.get_feature_aliases = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_feature_aliases';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'GenomeAnnotationAPI.get_cds_by_gene',
-                        params = [inputs_get_cds_by_gene];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_cds_by_mrna = function (inputs_mrna_id_list) {
+        /*
+         * inputs_get_cds_by_gene
+         */
+        this.get_cds_by_gene = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_cds_by_gene';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'GenomeAnnotationAPI.get_cds_by_mrna',
-                        params = [inputs_mrna_id_list];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_gene_by_cds = function (inputs_get_gene_by_cds) {
+        /*
+         * inputs_mrna_id_list
+         */
+        this.get_cds_by_mrna = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_cds_by_mrna';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'GenomeAnnotationAPI.get_gene_by_cds',
-                        params = [inputs_get_gene_by_cds];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_gene_by_mrna = function (inputs_get_gene_by_mrna) {
+        /*
+         * inputs_get_gene_by_cds
+         */
+        this.get_gene_by_cds = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_gene_by_cds';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'GenomeAnnotationAPI.get_gene_by_mrna',
-                        params = [inputs_get_gene_by_mrna];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_mrna_by_cds = function (inputs_get_mrna_by_cds) {
+        /*
+         * inputs_get_gene_by_mrna
+         */
+        this.get_gene_by_mrna = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_gene_by_mrna';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'GenomeAnnotationAPI.get_mrna_by_cds',
-                        params = [inputs_get_mrna_by_cds];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_mrna_by_gene = function (inputs_get_mrna_by_gene) {
+        /*
+         * inputs_get_mrna_by_cds
+         */
+        this.get_mrna_by_cds = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_mrna_by_cds';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'GenomeAnnotationAPI.get_mrna_by_gene',
-                        params = [inputs_get_mrna_by_gene];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_mrna_exons = function (inputs_get_mrna_exons) {
+        /*
+         * inputs_get_mrna_by_gene
+         */
+        this.get_mrna_by_gene = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_mrna_by_gene';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'GenomeAnnotationAPI.get_mrna_exons',
-                        params = [inputs_get_mrna_exons];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_mrna_utrs = function (inputs_get_mrna_utrs) {
+        /*
+         * inputs_get_mrna_exons
+         */
+        this.get_mrna_exons = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_mrna_exons';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'GenomeAnnotationAPI.get_mrna_utrs',
-                        params = [inputs_get_mrna_utrs];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_summary = function (inputs_get_summary) {
+        /*
+         * inputs_get_mrna_utrs
+         */
+        this.get_mrna_utrs = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_mrna_utrs';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'GenomeAnnotationAPI.get_summary',
-                        params = [inputs_get_summary];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.save_summary = function (inputs_save_summary) {
+        /*
+         * inputs_get_summary
+         */
+        this.get_summary = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_summary';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'GenomeAnnotationAPI.save_summary',
-                        params = [inputs_save_summary];
-                    return jsonRpc.request(serviceStatus.url, method, params, 2, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_combined_data = function (params) {
+        /*
+         * inputs_save_summary
+         */
+        this.save_summary = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'save_summary';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'GenomeAnnotationAPI.get_combined_data',
-                        params = [params];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 2, options());
                 });
         };
 
+        /*
+         * params
+         */
+        this.get_combined_data = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_combined_data';
+
+            return this.lookupModule()
+                .then(function (serviceStatus) {
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
+                });
+        };
+
+        /*
+         * 
+         */
         this.status = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'status';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'GenomeAnnotationAPI.status',
-                        params = [];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
     }

--- a/dist/amd/kb_sdk_clients/TaxonAPI/dev/TaxonAPIClient.js
+++ b/dist/amd/kb_sdk_clients/TaxonAPI/dev/TaxonAPIClient.js
@@ -18,6 +18,7 @@ define([
      */
     function TaxonAPI(arg) {
         // Establish an auth object which has properties token and user_id.
+        var module = 'TaxonAPI';
         var auth;
         if (typeof arg.auth === 'function') {
             auth = arg.auth();
@@ -43,182 +44,272 @@ define([
         }
 
         this.lookupModule = function () {
-            var method = 'ServiceWizard.get_service_status',
+            var func = 'get_service_status',
                 params = [{
-                        module_name: 'TaxonAPI',
+                        module_name: module,
                         version: arg.version || 'dev'
                     }];
-            return jsonRpc.request(arg.url, method, params, 1, options());
+            return jsonRpc.request(arg.url, 'ServiceWizard', func, params, 1, options());
         };
 
-        this.get_parent = function (ref) {
+        /*
+         * ref
+         */
+        this.get_parent = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_parent';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'TaxonAPI.get_parent',
-                        params = [ref];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_children = function (ref) {
+        /*
+         * ref
+         */
+        this.get_children = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_children';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'TaxonAPI.get_children',
-                        params = [ref];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_genome_annotations = function (ref) {
+        /*
+         * ref
+         */
+        this.get_genome_annotations = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_genome_annotations';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'TaxonAPI.get_genome_annotations',
-                        params = [ref];
-                    jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_scientific_lineage = function (ref) {
+        /*
+         * ref
+         */
+        this.get_scientific_lineage = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_scientific_lineage';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'TaxonAPI.get_scientific_lineage',
-                        params = [ref];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_scientific_name = function (ref) {
+        /*
+         * ref
+         */
+        this.get_scientific_name = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_scientific_name';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'TaxonAPI.get_scientific_name',
-                        params = [ref];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_taxonomic_id = function (ref) {
+        /*
+         * ref
+         */
+        this.get_taxonomic_id = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_taxonomic_id';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'TaxonAPI.get_taxonomic_id',
-                        params = [ref];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_kingdom = function (ref) {
+        /*
+         * ref
+         */
+        this.get_kingdom = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_kingdom';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'TaxonAPI.get_kingdom',
-                        params = [ref];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_domain = function (ref) {
+        /*
+         * ref
+         */
+        this.get_domain = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_domain';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'TaxonAPI.get_domain',
-                        params = [ref];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_genetic_code = function (ref) {
+        /*
+         * ref
+         */
+        this.get_genetic_code = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_genetic_code';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'TaxonAPI.get_genetic_code',
-                        params = [ref];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_aliases = function (ref) {
+        /*
+         * ref
+         */
+        this.get_aliases = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_aliases';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'TaxonAPI.get_aliases',
-                        params = [ref];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_info = function (ref) {
+        /*
+         * ref
+         */
+        this.get_info = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_info';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'TaxonAPI.get_info',
-                        params = [ref];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_history = function (ref) {
+        /*
+         * ref
+         */
+        this.get_history = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_history';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'TaxonAPI.get_history',
-                        params = [ref];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_provenance = function (ref) {
+        /*
+         * ref
+         */
+        this.get_provenance = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_provenance';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'TaxonAPI.get_provenance',
-                        params = [ref];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_id = function (ref) {
+        /*
+         * ref
+         */
+        this.get_id = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_id';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'TaxonAPI.get_id',
-                        params = [ref];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_name = function (ref) {
+        /*
+         * ref
+         */
+        this.get_name = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_name';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'TaxonAPI.get_name',
-                        params = [ref];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
         
-        this.get_all_data = function (p) {
+        // NOTE: arguments to the api call should match the spec.
+        // Thus the somewhat arcane structure internally. The anonymous immmediately
+        // executed functional creates a barrier between the injected parameter names
+        // in the main api function , and the internal implementation of constructing
+        // the actual service call. Otherwise there could always be a conflict between
+        // the injected parameters and any internal variables.
+        // Of course, this could be caught at spec-time if the spec were aware of 
+        // reserved 
+        
+        /*
+         * ref
+         */
+        this.get_all_data = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_all_data';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'TaxonAPI.get_all_data',
-                        params = [p];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_decorated_scientific_lineage = function (p) {
+        /*
+         * ref
+         */
+        this.get_decorated_scientific_lineage = function () {
+            // We need to use the raw arguments magic local variable rather than
+            // explicit arguments because the arguments are injected from specs
+            // and may conflict with Javascript reserved words, variables
+            // internal to this function, or shadow other symbols we need 
+            // (e.g. the options function).
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_decorated_scientific_lineage';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'TaxonAPI.get_decorated_scientific_lineage',
-                        params = [p];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
-        this.get_version = function (ref) {
+        /*
+         * ref
+         */
+        this.get_version = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'get_version';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'TaxonAPI.get_version',
-                        params = [ref];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
 
+        /*
+         * 
+         */
         this.status = function () {
+            var params = Array.prototype.slice.call(arguments),
+                func = 'status';
+
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'TaxonAPI.status',
-                        params = [];
-                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                    return jsonRpc.request(serviceStatus.url, module, func, params, 1, options());
                 });
         };
     }

--- a/dist/amd/kb_sdk_clients/TaxonAPI/dev/TaxonAPIClient.js
+++ b/dist/amd/kb_sdk_clients/TaxonAPI/dev/TaxonAPIClient.js
@@ -189,7 +189,7 @@ define([
         this.get_all_data = function (p) {
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'TaxonAPI.get_version',
+                    var method = 'TaxonAPI.get_all_data',
                         params = [p];
                     return jsonRpc.request(serviceStatus.url, method, params, 1, options());
                 });
@@ -198,7 +198,7 @@ define([
         this.get_decorated_scientific_lineage = function (p) {
             return this.lookupModule()
                 .then(function (serviceStatus) {
-                    var method = 'TaxonAPI.get_version',
+                    var method = 'TaxonAPI.get_decorated_scientific_lineage',
                         params = [p];
                     return jsonRpc.request(serviceStatus.url, method, params, 1, options());
                 });

--- a/dist/amd/kb_sdk_clients/TaxonAPI/dev/TaxonAPIClient.js
+++ b/dist/amd/kb_sdk_clients/TaxonAPI/dev/TaxonAPIClient.js
@@ -185,6 +185,24 @@ define([
                     return jsonRpc.request(serviceStatus.url, method, params, 1, options());
                 });
         };
+        
+        this.get_all_data = function (p) {
+            return this.lookupModule()
+                .then(function (serviceStatus) {
+                    var method = 'TaxonAPI.get_version',
+                        params = [p];
+                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                });
+        };
+
+        this.get_decorated_scientific_lineage = function (p) {
+            return this.lookupModule()
+                .then(function (serviceStatus) {
+                    var method = 'TaxonAPI.get_version',
+                        params = [p];
+                    return jsonRpc.request(serviceStatus.url, method, params, 1, options());
+                });
+        };
 
         this.get_version = function (ref) {
             return this.lookupModule()

--- a/dist/amd/kb_sdk_clients/ajax.js
+++ b/dist/amd/kb_sdk_clients/ajax.js
@@ -57,16 +57,16 @@ define([
             xhr.onload = function () {
                 if (xhr.status >= 400 && xhr.status < 500) {
                     reject(new ClientException(xhr.status, 'Client Error', xhr));
-                }
-                if (xhr.status >= 500) {
+                } else if (xhr.status >= 500) {
                     reject(new ServerException(xhr.status, 'Server Error', xhr));
-                }
-                
-                // var buf = new Uint8Array(xhr.response);
-                try {
-                    resolve(xhr.response);
-                } catch (ex) {
-                    reject(ex);
+                } else {
+
+                    // var buf = new Uint8Array(xhr.response);
+                    try {
+                        resolve(xhr.response);
+                    } catch (ex) {
+                        reject(ex);
+                    }
                 }
             };
             

--- a/dist/amd/kb_sdk_clients/exceptions.js
+++ b/dist/amd/kb_sdk_clients/exceptions.js
@@ -1,0 +1,63 @@
+/*global define */
+/*jslint white:true,browser:true*/
+define([], function () {
+    'use strict';
+
+/*
+     * A reponse which is invalid.
+     * A valid response is most likely a non- or improper-JSON string
+     * 
+     */
+    function InvalidResponseError(originalError, url, data) {
+        this.originalError = originalError;
+        this.url = url;
+        this.responseData = data;
+    }
+    InvalidResponseError.prototype = Object.create(Error.prototype);
+    InvalidResponseError.prototype.constructor = InvalidResponseError;
+    InvalidResponseError.prototype.name = 'InvalidResponseError';
+
+    /*
+     * An error returned by the http server (an http server error)
+     */
+    function RequestError(statusCode, statusText, url, message) {
+        this.url = url;
+        this.message = message;
+        this.statusCode = statusCode;
+        this.statusText = statusText;
+    }
+    RequestError.prototype = Object.create(Error.prototype);
+    RequestError.prototype.constructor = RequestError;
+    RequestError.prototype.name = 'RequestError';
+    
+    function JsonRpcError(module, func, params, url, error) {
+        this.url = url;
+        this.message = error.message;
+        this.detail = error.error;
+        this.type = error.name;
+        this.code = error.code;
+        this.module = module;
+        this.func = func;
+        this.params = params;
+    }
+    JsonRpcError.prototype = Object.create(Error.prototype);
+    JsonRpcError.prototype.constructor = JsonRpcError;
+    JsonRpcError.prototype.name = 'JsonRpcError';
+    
+    function AttributeError(module, func, originalError) {
+        this.module = module;
+        this.func = func;
+        this.originalError = originalError;
+    }
+    AttributeError.prototype = Object.create(Error.prototype);
+    AttributeError.prototype.constructor = AttributeError;
+    AttributeError.prototype.name = 'AttributeError';
+    
+    return Object.freeze({
+        InvalidResponseError: InvalidResponseError,
+        RequestError: RequestError,
+        JsonRpcError: JsonRpcError,
+        AttributeError: AttributeError
+    });
+    
+});

--- a/dist/amd/kb_sdk_clients/jsonRpc-jquery.js
+++ b/dist/amd/kb_sdk_clients/jsonRpc-jquery.js
@@ -1,36 +1,7 @@
 /*global define */
 /*jslint white:true,browser:true*/
-define(['jquery', 'bluebird'], function ($, Promise) {
+define(['jquery', 'bluebird', './exceptions'], function ($, Promise, exceptions) {
     'use strict';
-
-    /*
-     * A reponse which is invalid.
-     * A valid response is most likely a non- or improper-JSON string
-     * 
-     */
-    function InvalidResponseError(originalError, url, data) {
-        this.name = 'InvalidResponseError';
-        this.originalError = originalError;
-        this.url = url;
-        this.responseData = data;
-    }
-    InvalidResponseError.prototype = Object.create(Error);
-    InvalidResponseError.prototype.constructor = InvalidResponseError;
-
-    /*
-     * An error returned by the http server (an http server error)
-     */
-    function RequestError(statusCode, statusText, jqueryTextStatus, url, message) {
-        this.name = 'ServerError';
-        this.url = url;
-        this.message = message;
-        this.statusCode = statusCode;
-        this.statusText = statusText;
-        this.jqueryErrorString = jqueryTextStatus;
-    }
-    RequestError.prototype = Object.create(Error);
-    RequestError.prototype.constructor = RequestError;
-
 
     function request(url, method, params, numRets, options) {
         var rpc = {
@@ -51,8 +22,6 @@ define(['jquery', 'bluebird'], function ($, Promise) {
             };
         }
         
-        console.log('sending', url, rpc);
-
         return new Promise(function (resolve, reject) {
             $.ajax({
                 url: url,
@@ -72,7 +41,7 @@ define(['jquery', 'bluebird'], function ($, Promise) {
                             resolve(resp.result);
                         }
                     } catch (err) {
-                        reject(new InvalidResponseError(err, url, data));
+                        reject(new exceptions.InvalidResponseError(err, url, data));
                     }
                 },
                 error: function (xhr, textStatus) {
@@ -90,10 +59,10 @@ define(['jquery', 'bluebird'], function ($, Promise) {
                         } catch (err) {
                             // A server error which is not valid JSON.
                             // This actually is the expected condition for a server error.
-                            reject(new RequestError(xhr.status, xhr.statusText, textStatus, url, xhr.responseText));
+                            reject(new exceptions.RequestError(xhr.status, xhr.statusText, textStatus, url, xhr.responseText));
                         }
                     } else {
-                        reject(new RequestError(xhr.status, xhr.statusText, textStatus, url, 'Unknown Error'));
+                        reject(new exceptions.RequestError(xhr.status, xhr.statusText, url, 'Unknown Error'));
                     }
                 }
             });
@@ -101,8 +70,6 @@ define(['jquery', 'bluebird'], function ($, Promise) {
     }
 
     return Object.freeze({
-        request: request,
-        InvalidResponseError: InvalidResponseError,
-        ServerError: RequestError
+        request: request
     });
 });


### PR DESCRIPTION
While exploring Mike's PR, and the issue with the params argument clashing with an internal variable reference, I determined to take a minute to explore the problem.
Ended up coming up with an idiomatic Javascript technique which solves not just the variable clash, but also other potential clashes with Javascript reserved names. The essence is that we should not be injecting any references into the library from the spec. The spec compile would need to be aware of all potential conflicts -- difficult at the least. 
So we take the raw "arguments", coerce it to an Array, and pass that as the method parameters. 
This means that the function definitions do not have any arguments. This is too bad, from a self-documenting perspective, but the arguments can be placed into comments above the methods if devs want to explore the api through the code.
Also separated exceptions into their own module, makes it easier to just import the exceptions.
